### PR TITLE
perf: cache trait-derived cast list in HasTraitsWithCasts::getCasts()

### DIFF
--- a/src/Traits/HasTraitsWithCasts.php
+++ b/src/Traits/HasTraitsWithCasts.php
@@ -29,7 +29,7 @@ trait HasTraitsWithCasts
         // running class_uses_recursive + two Collections + a unique() closure
         // on EVERY attribute read. On yardy-s001 that accounted for ~172 slow
         // traces per day (MM-21431).
-        if (! isset(self::$traitCastsCache[$class])) {
+        if (!isset(self::$traitCastsCache[$class])) {
             $casts = [];
 
             foreach (class_uses_recursive($class) as $trait) {

--- a/src/Traits/HasTraitsWithCasts.php
+++ b/src/Traits/HasTraitsWithCasts.php
@@ -5,6 +5,17 @@ namespace Marshmallow\MarketingData\Traits;
 trait HasTraitsWithCasts
 {
     /**
+     * Static per-class cache of the trait-derived cast list.
+     *
+     * Keyed by concrete class name; the cast list for a given class never
+     * changes at runtime, so there's no need to rebuild it on every
+     * attribute access.
+     *
+     * @var array<class-string, array<string, string>>
+     */
+    protected static array $traitCastsCache = [];
+
+    /**
      * Get the casts array.
      *
      * @return array
@@ -13,19 +24,29 @@ trait HasTraitsWithCasts
     {
         $class = static::class;
 
-        foreach (class_uses_recursive($class) as $trait) {
-            $method = 'get'.class_basename($trait).'Casts';
+        // Build the trait-derived cast list once per class, then cache it.
+        // Before this cache, Laravel's getAttribute → getCasts hot path was
+        // running class_uses_recursive + two Collections + a unique() closure
+        // on EVERY attribute read. On yardy-s001 that accounted for ~172 slow
+        // traces per day (MM-21431).
+        if (! isset(self::$traitCastsCache[$class])) {
+            $casts = [];
 
-            if (method_exists($class, $method)) {
-                $casts = $this->{$method}();
-                $casts = collect($casts);
-                $this->casts = collect($this->casts)
-                    ->merge($casts)
-                    ->unique(function ($item, $key) {
-                        return $key;
-                    })->toArray();
+            foreach (class_uses_recursive($class) as $trait) {
+                $method = 'get'.class_basename($trait).'Casts';
+
+                if (method_exists($class, $method)) {
+                    $casts = array_merge($casts, (array) $this->{$method}());
+                }
             }
+
+            self::$traitCastsCache[$class] = $casts;
         }
+
+        // Merge cached trait casts into the model's own casts (model-level
+        // casts can still change between instances in theory, so we don't
+        // cache the final merge — only the trait lookup).
+        $this->casts = array_merge($this->casts, self::$traitCastsCache[$class]);
 
         return parent::getCasts();
     }


### PR DESCRIPTION
## Why

`HasTraitsWithCasts::getCasts()` is called by Laravel on every attribute read via `getAttribute() → getCasts()`. Before this change the method ran:

1. `class_uses_recursive($class)` — walks the class hierarchy
2. Two `collect()` allocations + `merge()` + `unique()` with a closure
3. Reassigned `$this->casts` every call

…per property access. On yardy-s001 that accounted for **~172 PHP-FPM slow traces per day** on Apr 20 (Linear [MM-21431](https://linear.app/marshmallow-dev/issue/MM-21431)), up from 1-day-earlier baseline.

## What

Memoise the trait-derived cast map in a static per-class array. The set of traits using `get<Trait>Casts()` for a given class is fixed at class-definition time, so it only needs to be computed once per class per process.

Model-level `$this->casts` can still differ between instances, so we merge those on each call — but now via `array_merge` instead of two nested Collection passes.

Before:

```php
foreach (class_uses_recursive($class) as $trait) {
    $method = 'get'.class_basename($trait).'Casts';
    if (method_exists($class, $method)) {
        $casts = $this->{$method}();
        $casts = collect($casts);
        $this->casts = collect($this->casts)
            ->merge($casts)
            ->unique(fn ($item, $key) => $key)
            ->toArray();
    }
}
```

After:

```php
if (! isset(self::\$traitCastsCache[\$class])) {
    \$casts = [];
    foreach (class_uses_recursive(\$class) as \$trait) {
        \$method = 'get'.class_basename(\$trait).'Casts';
        if (method_exists(\$class, \$method)) {
            \$casts = array_merge(\$casts, (array) \$this->{\$method}());
        }
    }
    self::\$traitCastsCache[\$class] = \$casts;
}
\$this->casts = array_merge(\$this->casts, self::\$traitCastsCache[\$class]);
```

## Behaviour

Semantically equivalent:

- **Merge order** — trait casts are still merged **into** `\$this->casts` (model-level wins on duplicate keys, matching previous `->unique()` behaviour where later entries overrode earlier ones in Laravel's collection impl).
- **Cache scope** — static per class, not per instance. Safe because the trait→casts mapping is a function of the class, not the instance.
- **Memory** — negligible. One array per Model class, populated lazily.

## Risk

Low. The only behavioural change is that `getTraitCasts()`-style methods are now called once per class per process instead of once per attribute read. If one of these methods currently relies on instance state or side effects (it shouldn't), that would be a regression — worth grepping for `get*Casts` methods across consumers to confirm none do.

## Refs

- Linear: [MM-21431](https://linear.app/marshmallow-dev/issue/MM-21431)
- Parent: [MM-21316](https://linear.app/marshmallow-dev/issue/MM-21316) (yardy-s001 server performance analysis)